### PR TITLE
chore: cherry pick status-go changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Jetbrains IDE files
+.idea

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/status-im/extkeys
 
-go 1.13
+go 1.21
 
 require (
 	github.com/btcsuite/btcd v0.20.1-beta
@@ -10,3 +10,5 @@ require (
 	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf
 	golang.org/x/text v0.3.2
 )
+
+require golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/status-im/extkeys
 go 1.13
 
 require (
-	github.com/btcsuite/btcd v0.20.0-beta
+	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	// go-ethereum v1.9.5 is used across all libraries in status-im
 	github.com/ethereum/go-ethereum v1.9.5

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,6 @@
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/btcsuite/btcd v0.20.0-beta h1:DnZGUjFbRkpytojHWwy6nfUSA7vFrzWXDLpFNzt74ZA=
-github.com/btcsuite/btcd v0.20.0-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
+github.com/btcsuite/btcd v0.20.1-beta h1:Ik4hyJqN8Jfyv3S4AGBOmyouMsYE3EdYODkMbQjwPGw=
+github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:yJzD/yFppdVCf6ApMkVy8cUxV0XrxdP9rVf6D87/Mng=
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
@@ -9,11 +9,10 @@ github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVa
 github.com/btcsuite/snappy-go v0.0.0-20151229074030-0bdef8d06723/go.mod h1:8woku9dyThutzjeg+3xrA5iCpBRH8XEEg3lh6TiUghc=
 github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtEyQwv5/p4Mg4C0fgbePVuGr935/5ddU9Z3TmDRY=
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
+github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495 h1:6IyqGr3fnd0tM3YxipK27TUskaOVUjU2nG45yzwcQKY=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ethereum/go-ethereum v1.9.5 h1:4oxsF+/3N/sTgda9XTVG4r+wMVLsveziSMcK83hPbsk=
 github.com/ethereum/go-ethereum v1.9.5/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
-github.com/ethereum/go-ethereum v1.9.6 h1:EacwxMGKZezZi+m3in0Tlyk0veDQgnfZ9BjQqHAaQLM=
-github.com/ethereum/go-ethereum v1.9.6/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
@@ -32,11 +31,13 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=

--- a/hdkey_test.go
+++ b/hdkey_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg"
+
 	"github.com/ethereum/go-ethereum/crypto"
 )
 

--- a/mnemonic.go
+++ b/mnemonic.go
@@ -24,6 +24,7 @@ import (
 // https://github.com/trezor/trezor-crypto/blob/master/bip39.c
 // https://github.com/trezor/python-mnemonic/blob/master/mnemonic/mnemonic.py
 // https://github.com/bitpay/bitcore-mnemonic/blob/master/lib/mnemonic.js (used in eth-lightwallet.js)
+// https://github.com/tyler-smith/go-bip39/blob/master/bip39.go
 
 const defaultSalt = "mnemonic"
 
@@ -73,6 +74,21 @@ var (
 	rightShift11BitsDivider = big.NewInt(2048)
 	bigOne                  = big.NewInt(1)
 	bigTwo                  = big.NewInt(2)
+
+	wordLengthChecksumMasksMapping = map[int]*big.Int{
+		12: big.NewInt(15),
+		15: big.NewInt(31),
+		18: big.NewInt(63),
+		21: big.NewInt(127),
+		24: big.NewInt(255),
+	}
+
+	wordLengthChecksumShiftMapping = map[int]*big.Int{
+		12: big.NewInt(16),
+		15: big.NewInt(8),
+		18: big.NewInt(4),
+		21: big.NewInt(2),
+	}
 )
 
 // Language is language identifier
@@ -201,11 +217,11 @@ func (m *Mnemonic) MnemonicPhrase(strength EntropyStrength, language Language) (
 	return strings.Join(words, wordSeperator), nil
 }
 
-// ValidMnemonic validates mnemonic string
-func (m *Mnemonic) ValidMnemonic(mnemonic string, language Language) bool {
+// ValidateMnemonic validates that all words from a mnemonic string are in wordlist and that checksum is valid
+func (m *Mnemonic) ValidateMnemonic(mnemonic string, language Language) error {
 	wordList, err := m.WordList(language)
 	if err != nil {
-		return false
+		return errors.New("invalid language specified")
 	}
 
 	// Create a list of all the words in the mnemonic sentence
@@ -216,17 +232,64 @@ func (m *Mnemonic) ValidMnemonic(mnemonic string, language Language) bool {
 
 	// The number of words should be 12, 15, 18, 21 or 24
 	if numOfWords%3 != 0 || numOfWords < 12 || numOfWords > 24 {
-		return false
+		return errors.New("mnemonic contains an invalid number of words")
 	}
+
+	// Create reverse lookup map for dictionary
+	wordMap := map[string]int{}
+	for i, v := range wordList {
+		wordMap[v] = i
+	}
+
+	b := big.NewInt(0)
 
 	// Check if all words belong in the wordlist
 	for i := 0; i < numOfWords; i++ {
-		if !contains(wordList, words[i]) {
-			return false
+
+		wordIndex, ok := wordMap[words[i]]
+		if !ok {
+			return fmt.Errorf("word %s not found in the dictionary", words[i])
 		}
+		var wordBytes [2]byte
+		binary.BigEndian.PutUint16(wordBytes[:], uint16(wordIndex))
+		b = b.Mul(b, rightShift11BitsDivider)
+		b = b.Or(b, big.NewInt(0).SetBytes(wordBytes[:]))
 	}
 
-	return true
+	checksum := big.NewInt(0)
+	checksumMask := wordLengthChecksumMasksMapping[numOfWords]
+	checksum = checksum.And(b, checksumMask)
+
+	b.Div(b, big.NewInt(0).Add(checksumMask, bigOne))
+
+	// Calculate entropy from mnemonic
+	entropy := b.Bytes()
+	entropy = padByteSlice(entropy, len(words)/3*4)
+
+	// Calculate checksum from entropy derived above
+	hasher := sha256.New()
+	if _, err := hasher.Write(entropy); err != nil {
+		return err
+	}
+
+	computedChecksumBytes := hasher.Sum(nil)
+	computedChecksum := big.NewInt(int64(computedChecksumBytes[0]))
+
+	if l := len(words); l != 24 {
+		checksumShift := wordLengthChecksumShiftMapping[l]
+		computedChecksum.Div(computedChecksum, checksumShift)
+	}
+
+	if checksum.Cmp(computedChecksum) != 0 {
+		return errors.New("checksum for mnemonic seed is invalid")
+	}
+
+	return nil
+}
+
+// ValidMnemonic validates mnemonic string
+func (m *Mnemonic) ValidMnemonic(mnemonic string, language Language) bool {
+	return m.ValidateMnemonic(mnemonic, language) == nil
 }
 
 // WordList returns list of words for a given language
@@ -235,33 +298,6 @@ func (m *Mnemonic) WordList(language Language) (*WordList, error) {
 		return nil, fmt.Errorf("language word list is missing (language id: %d)", language)
 	}
 	return m.wordLists[language], nil
-}
-
-func contains(wordList *WordList, e string) bool {
-	// tries binary search first, then resorts to full list traversal
-	i, j := 0, len(wordList)
-	for i < j {
-		h := i + (j-i)/2
-
-		// i < h < j
-		if wordList[h] >= e {
-			j = h
-		} else {
-			i = h + 1
-		}
-	}
-
-	if j > 0 && j < len(wordList) && wordList[j] == e {
-		return true
-	}
-
-	// traverse list
-	for _, a := range wordList {
-		if a == e {
-			return true
-		}
-	}
-	return false
 }
 
 func padByteSlice(slice []byte, length int) []byte { //nolint: unparam


### PR DESCRIPTION
Cherry-pick changes made in `status-go/extkeys`:
- https://github.com/status-im/status-go/pull/1713
- https://github.com/status-im/status-go/pull/1861
- https://github.com/status-im/status-go/pull/1878

Also:
- Added `.gitignore`
- Updated `btcsuite/btcd` to 0.20.1 (this is the version that was used in `status-go/extkeys`
- Update to Go 1.21